### PR TITLE
Fix DOI link in README for citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In short:
 If you use this code or the GPU-based point-in-polygon algorithm in a
 scientific publication, please cite:
 
-> Muscat, M. (2026). biopsylocalization-python. Zenodo. DOI: https://doi.org/10.5281/zenodo.15700661
+> Muscat, M. (2026). biopsylocalization-python. Zenodo. DOI: https://doi.org/10.5281/zenodo.15700660
 
 For commercial licensing inquiries, please contact:
 `matthew.muscat@mail.mcgill.ca`.


### PR DESCRIPTION
Corrected DOI link for the biopsylocalization-python citation.